### PR TITLE
Fix an issue of migrating sfdc46 branch to ballerina 1.2.0

### DIFF
--- a/Ballerina.lock
+++ b/Ballerina.lock
@@ -1,4 +1,4 @@
 org_name = "wso2"
-version = "0.10.1"
+version = "0.11.0"
 lockfile_version = "1.0.0"
 ballerina_version = "1.2.0"


### PR DESCRIPTION
## Purpose
The Ballerina lock file needs to contain the updated version number to facilitate pushing the connector code to Ballerina Central.

## Goals
Update the version number in Ballerina.toml file.